### PR TITLE
Use int64 instead of uint64 everywhere

### DIFF
--- a/matching.go
+++ b/matching.go
@@ -28,7 +28,7 @@ func ReducePeople(people People, ext external.Matcher, blacklist Blacklist) erro
 
 	peopleGraph := simple.NewUndirectedGraph()
 	for index, person := range people {
-		peopleGraph.AddNode(node{person, int64(index)})
+		peopleGraph.AddNode(node{person, index})
 	}
 
 	// Add edges by the same unpopular email
@@ -39,9 +39,9 @@ func ReducePeople(people People, ext external.Matcher, blacklist Blacklist) erro
 				continue
 			}
 			if val, ok := email2id[email]; ok {
-				peopleGraph.SetEdge(peopleGraph.NewEdge(val, peopleGraph.Node(int64(index))))
+				peopleGraph.SetEdge(peopleGraph.NewEdge(val, peopleGraph.Node(index)))
 			} else {
-				email2id[email] = peopleGraph.Node(int64(index))
+				email2id[email] = peopleGraph.Node(index)
 			}
 		}
 	}
@@ -54,17 +54,17 @@ func ReducePeople(people People, ext external.Matcher, blacklist Blacklist) erro
 				continue
 			}
 			if val, ok := name2id[name.String()]; ok {
-				peopleGraph.SetEdge(peopleGraph.NewEdge(val, peopleGraph.Node(int64(index))))
+				peopleGraph.SetEdge(peopleGraph.NewEdge(val, peopleGraph.Node(index)))
 			} else {
-				name2id[name.String()] = peopleGraph.Node(int64(index))
+				name2id[name.String()] = peopleGraph.Node(index)
 			}
 		}
 	}
 
 	for _, component := range topo.ConnectedComponents(peopleGraph) {
-		var toMerge []uint64
+		var toMerge []int64
 		for _, node := range component {
-			toMerge = append(toMerge, uint64(node.ID()))
+			toMerge = append(toMerge, node.ID())
 		}
 		people.Merge(toMerge...)
 	}

--- a/people.go
+++ b/people.go
@@ -35,7 +35,7 @@ type NameWithRepo struct {
 
 // Person is a single individual that can have multiple names and emails.
 type Person struct {
-	ID             uint64
+	ID             int64
 	NamesWithRepos []NameWithRepo
 	Emails         []string
 }
@@ -78,11 +78,11 @@ func (p Person) String() string {
 }
 
 // People is a map of persons indexed by their ID.
-type People map[uint64]*Person
+type People map[int64]*Person
 
 func newPeople(persons []rawPerson, blacklist Blacklist) (People, error) {
 	result := make(People)
-	var id uint64
+	var id int64
 	var nameWithRepo NameWithRepo
 
 	for _, p := range persons {
@@ -116,7 +116,7 @@ func newPeople(persons []rawPerson, blacklist Blacklist) (People, error) {
 }
 
 type parquetPerson struct {
-	ID    uint64 `parquet:"name=id, type=UINT_64"`
+	ID    int64  `parquet:"name=id, type=INT_64"`
 	Email string `parquet:"name=email, type=UTF8"`
 	Name  string `parquet:"name=name, type=UTF8"`
 	Repo  string `parquet:"name=repo, type=UTF8"`
@@ -179,7 +179,7 @@ func (p People) WriteToParquet(path string) (err error) {
 		logrus.Fatal("Failed to create new parquet writer.", err)
 	}
 	pw.CompressionType = parquet.CompressionCodec_UNCOMPRESSED
-	p.ForEach(func(key uint64, val *Person) bool {
+	p.ForEach(func(key int64, val *Person) bool {
 		for _, email := range val.Emails {
 			if err := pw.Write(parquetPerson{val.ID, email, "", ""}); err != nil {
 				return true
@@ -197,7 +197,7 @@ func (p People) WriteToParquet(path string) (err error) {
 }
 
 // Merge several persons with the given ids.
-func (p People) Merge(ids ...uint64) uint64 {
+func (p People) Merge(ids ...int64) int64 {
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	p0 := p[ids[0]]
 	for _, id := range ids[1:] {
@@ -212,8 +212,8 @@ func (p People) Merge(ids ...uint64) uint64 {
 
 // ForEach executes a function over each person in the collection.
 // The order is fixed and constant.
-func (p People) ForEach(f func(uint64, *Person) bool) {
-	var keys = make([]uint64, 0, len(p))
+func (p People) ForEach(f func(int64, *Person) bool) {
+	var keys = make([]int64, 0, len(p))
 	for k := range p {
 		keys = append(keys, k)
 	}

--- a/people_test.go
+++ b/people_test.go
@@ -41,7 +41,7 @@ func TestTwoPeopleMerge(t *testing.T) {
 		3: {ID: 3, NamesWithRepos: []NameWithRepo{{"alice", ""}}, Emails: []string{"alice@google.com"}},
 		4: {ID: 4, NamesWithRepos: []NameWithRepo{{"bob", ""}}, Emails: []string{"bob@google.com"}},
 	}
-	require.Equal(uint64(1), mergedID)
+	require.Equal(int64(1), mergedID)
 	require.Equal(expected, people)
 
 	mergedID = people.Merge(3, 4)
@@ -51,7 +51,7 @@ func TestTwoPeopleMerge(t *testing.T) {
 			NamesWithRepos: []NameWithRepo{{"alice", ""}, {"bob", ""}},
 			Emails:         []string{"alice@google.com", "bob@google.com"}},
 	}
-	require.Equal(uint64(3), mergedID)
+	require.Equal(int64(3), mergedID)
 	require.Equal(expected, people)
 
 	mergedID = people.Merge(1, 3)
@@ -60,7 +60,7 @@ func TestTwoPeopleMerge(t *testing.T) {
 			NamesWithRepos: []NameWithRepo{{"alice", ""}, {"bob", ""}},
 			Emails:         []string{"alice@google.com", "bob@google.com"}},
 	}
-	require.Equal(uint64(1), mergedID)
+	require.Equal(int64(1), mergedID)
 	require.Equal(expected, people)
 }
 
@@ -73,19 +73,19 @@ func TestFourPeopleMerge(t *testing.T) {
 			NamesWithRepos: []NameWithRepo{{"alice", ""}, {"bob", ""}},
 			Emails:         []string{"alice@google.com", "bob@google.com"}},
 	}
-	require.Equal(t, uint64(1), mergedID)
+	require.Equal(t, int64(1), mergedID)
 	require.Equal(t, expected, people)
 }
 
 func TestPeopleForEach(t *testing.T) {
 	people, err := newPeople(rawPersons, newTestBlacklist(t))
 	require.NoError(t, err)
-	var keys = make([]uint64, 0, len(people))
-	people.ForEach(func(key uint64, val *Person) bool {
+	var keys = make([]int64, 0, len(people))
+	people.ForEach(func(key int64, val *Person) bool {
 		keys = append(keys, key)
 		return false
 	})
-	require.Equal(t, []uint64{1, 2, 3, 4}, keys)
+	require.Equal(t, []int64{1, 2, 3, 4}, keys)
 }
 
 func tempFile(t *testing.T, pattern string) (*os.File, func()) {


### PR DESCRIPTION
uint64 to int64 part of https://github.com/src-d/eee-identity-matching/pull/19

I changed all uint64 types to just int64 because:

Graph Nodes uses int64 so we convert types anyway and have both uint64 and int64.
python script cannot read parquet with uint type:
pyspark Parquet type not supported UINT_64
there are some issues around that error and I did not find a workaround to fix that.