### PR TITLE
Add cache to external matcher

### DIFF
--- a/cmd/match-identities/main.go
+++ b/cmd/match-identities/main.go
@@ -18,15 +18,16 @@ import (
 )
 
 type cliArgs struct {
-	Host     string
-	Port     uint
-	User     string
-	Password string
-	Output   string
-	External string
-	APIURL   string
-	Token    string
-	Cache    string
+	Host          string
+	Port          uint
+	User          string
+	Password      string
+	Output        string
+	External      string
+	APIURL        string
+	Token         string
+	Cache         string
+	ExternalCache string
 }
 
 func main() {
@@ -47,6 +48,12 @@ func main() {
 		extmatcher, err = external.Matchers[args.External](args.APIURL, args.Token)
 		if err != nil {
 			logrus.Fatalf("failed to initialize %s: %v", args.External, err)
+		}
+		if args.ExternalCache != "" {
+			extmatcher, err = external.NewCachedMatcher(extmatcher, args.ExternalCache)
+			if err != nil {
+				logrus.Fatalf("failed to initialize cached %s: %v", args.External, err)
+			}
 		}
 	}
 
@@ -109,6 +116,7 @@ func parseArgs() cliArgs {
 		"API URL of the external matching service, the blank value means the public website")
 	flag.StringVar(&args.Token, "token", "", "API token for the external matching service")
 	flag.StringVar(&args.Cache, "cache", "cache.csv", "Path to the cached raw signatures")
+	flag.StringVar(&args.ExternalCache, "external-cache", "external-cache.csv", "Path to the cached External IDs.")
 	flag.CommandLine.SortFlags = false
 	flag.Parse()
 

--- a/external/cached_matcher.go
+++ b/external/cached_matcher.go
@@ -1,0 +1,167 @@
+package external
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"strings"
+)
+
+// UserName represents personal name and username of a person
+type UserName struct {
+	User  string
+	Name  string
+	Match bool // false if there in no match from the external API
+}
+
+// CachedMatcher is a wrapper for Matcher with a cache
+type CachedMatcher struct {
+	matcher      Matcher
+	cachePath    string
+	cache        map[string]UserName
+	saveFreq     int // Dump cache to file each saveFreq calls of matcher
+}
+
+// Exists reports whether the named file or directory exists.
+func Exists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// NewCachedMatcher creates a new matcher with a cache for a given matcher interface.
+func NewCachedMatcher(matcher Matcher, cachePath string) (CachedMatcher, error) {
+	if cachePath == "" {
+		return CachedMatcher{}, fmt.Errorf("cachePath cannot be empty")
+	}
+	logrus.Info("Using caching at %s for external matching", cachePath)
+	cachedMatcher := CachedMatcher{
+		matcher: matcher, cachePath: cachePath, cache: make(map[string]UserName),
+		saveFreq: 20}
+	var err error
+	if Exists(cachePath) {
+		err = cachedMatcher.LoadCache()
+	} else {
+		// Dump empty cache to make sure that it is possible to write to the file
+		err = cachedMatcher.DumpCache()
+	}
+	return cachedMatcher, err
+}
+
+// MatchByEmail returns the latest GitHub user with the given email.
+// If email was fetched already it uses cached value.
+// MatchByEmail runs `matcher.MatchByEmail` if not.
+func (m CachedMatcher) MatchByEmail(ctx context.Context, email string) (user, name string, err error) {
+	if username, exist := m.cache[email]; exist {
+		if username.Match {
+			return username.User, username.Name, nil
+		}
+		return "", "", ErrNoMatches
+	}
+	user, name, err = m.matcher.MatchByEmail(ctx, email)
+	if err == nil {
+		m.cache[email] = UserName{user, name, true}
+	}
+	if err == ErrNoMatches {
+		m.cache[email] = UserName{user, name, false}
+	}
+	if len(m.cache) % m.saveFreq == 0 {
+		err = m.DumpCache()
+	}
+	return user, name, err
+}
+
+// LoadCache reads GitHubMatcher cache from disk
+func (m CachedMatcher) LoadCache() error {
+	var file *os.File
+	file, err := os.Open(m.cachePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		errClose := file.Close()
+		if err == nil {
+			err = errClose
+		}
+	}()
+
+	r := csv.NewReader(file)
+	header := make(map[string]int)
+	rowIndex := 0
+	for {
+		record, err := r.Read()
+		rowIndex++
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if len(header) == 0 {
+			if len(record) != 4 {
+				return fmt.Errorf("invalid CSV file: should have 4 columns")
+			}
+			for index, name := range record {
+				header[name] = index
+			}
+		} else {
+			if len(record) != len(header) {
+				return fmt.Errorf("invalid CSV record: %s", strings.Join(record, ","))
+			}
+			m.cache[record[header["email"]]] = UserName{
+				record[header["user"]], record[header["name"]], record[header["match"]] == "true"}
+		}
+	}
+
+	if err == io.EOF {
+		err = nil
+	}
+
+	return nil
+}
+
+// DumpCache saves GitHubMatcher cache on disk
+func (m CachedMatcher) DumpCache() error {
+	logrus.Info("Dumping CachedMatcher cache.")
+	var file *os.File
+	file, err := os.Create(m.cachePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		errClose := file.Close()
+		if err == nil {
+			err = errClose
+		}
+	}()
+
+	writer := csv.NewWriter(file)
+	defer func() {
+		writer.Flush()
+		if err == nil {
+			err = writer.Error()
+		}
+	}()
+	err = writer.Write([]string{"email", "user", "name", "match"})
+	if err != nil {
+		return err
+	}
+	for email, username := range m.cache {
+		match := "false"
+		if username.Match {
+			match = "true"
+		}
+		err = writer.Write([]string{email, username.User, username.Name, match})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/external/cached_matcher_test.go
+++ b/external/cached_matcher_test.go
@@ -1,0 +1,122 @@
+package external
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func tempFile(t *testing.T, pattern string) (*os.File, func()) {
+	t.Helper()
+	f, err := ioutil.TempFile("", pattern)
+	require.NoError(t, err)
+	return f, func() {
+		require.NoError(t, f.Close())
+		require.NoError(t, os.Remove(f.Name()))
+	}
+}
+
+func TestNewCachedMatcher(t *testing.T) {
+	matcher, _ := NewGitHubMatcher("", githubTestToken)
+	cache, cleanup := tempFile(t, "*.csv")
+	defer cleanup()
+	_, err := cache.Write([]byte("email,user,name,match"))
+	require.NoError(t, err)
+	cachedMatcher, err := NewCachedMatcher(matcher, cache.Name())
+	expectedCachedMatcher := CachedMatcher{
+		matcher: matcher, cachePath: cache.Name(), cache: make(map[string]UserName), saveFreq: 20}
+	require.NoError(t, err)
+	require.Equal(t, expectedCachedMatcher, cachedMatcher)
+}
+
+func TestMatchByEmailAndDump(t *testing.T) {
+	matcher, _ := NewGitHubMatcher("", githubTestToken)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache, cleanup := tempFile(t, "*.csv")
+	defer cleanup()
+	_, err := cache.Write([]byte("email,user,name,match"))
+	require.NoError(t, err)
+	cachedMatcher, err := NewCachedMatcher(matcher, cache.Name())
+	require.NoError(t, err)
+
+	user, name, err := cachedMatcher.MatchByEmail(ctx, "mcuadros@gmail.com")
+	require.Equal(t, "mcuadros", user)
+	require.Equal(t, "Máximo Cuadros", name)
+	require.NoError(t, err)
+
+	err = cachedMatcher.DumpCache()
+	require.NoError(t, err)
+	cacheContent, err := ioutil.ReadFile(cache.Name())
+	require.NoError(t, err)
+	expectedCacheContent := "email,user,name,match\nmcuadros@gmail.com,mcuadros,Máximo Cuadros,true\n"
+	require.Equal(t, expectedCacheContent, string(cacheContent))
+}
+
+// TestNoMatchMatcher does not match any emails.
+type TestNoMatchMatcher struct {
+}
+
+func NewTestNoMatchMatcher(apiURL, token string) (Matcher, error) {
+	return TestNoMatchMatcher{}, nil
+}
+
+var ErrTest = errors.New("API error")
+
+// MatchByEmail returns the latest GitHub user with the given email.
+func (m TestNoMatchMatcher) MatchByEmail(ctx context.Context, email string) (user, name string, err error) {
+	if email == "new@gmail.com" {
+		return "new_user", "new_name", nil
+	}
+	return "", "", ErrTest
+}
+
+func TestMatchCacheOnly(t *testing.T) {
+	matcher, _ := NewTestNoMatchMatcher("", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache, cleanup := tempFile(t, "*.csv")
+	defer cleanup()
+	_, err := cache.Write([]byte(
+		"email,user,name,match\n" +
+			"mcuadros@gmail.com,mcuadros,Máximo Cuadros,true\n" +
+			"mcuadros-clone@gmail.com,,,false\n"))
+	require.NoError(t, err)
+	cachedMatcher, err := NewCachedMatcher(matcher, cache.Name())
+	require.NoError(t, err)
+
+	user, name, err := cachedMatcher.MatchByEmail(ctx, "mcuadros@gmail.com")
+	require.Equal(t, "mcuadros", user)
+	require.Equal(t, "Máximo Cuadros", name)
+	require.NoError(t, err)
+
+	user, name, err = cachedMatcher.MatchByEmail(ctx, "mcuadros-clone@gmail.com")
+	require.Equal(t, "", user)
+	require.Equal(t, "", name)
+	require.Equal(t, ErrNoMatches, err)
+
+	user, name, err = cachedMatcher.MatchByEmail(ctx, "errored@gmail.com")
+	require.Equal(t, "", user)
+	require.Equal(t, "", name)
+	require.Equal(t, ErrTest, err)
+
+	user, name, err = cachedMatcher.MatchByEmail(ctx, "new@gmail.com")
+	require.Equal(t, "new_user", user)
+	require.Equal(t, "new_name", name)
+	require.NoError(t, err)
+
+	err = cachedMatcher.DumpCache()
+	require.NoError(t, err)
+	cacheContent, err := ioutil.ReadFile(cache.Name())
+	require.NoError(t, err)
+	expectedCacheContent :=
+		"email,user,name,match\n" +
+			"mcuadros@gmail.com,mcuadros,Máximo Cuadros,true\n" +
+			"mcuadros-clone@gmail.com,,,false\n" +
+			"new@gmail.com,new_user,new_name,true\n"
+	require.Equal(t, expectedCacheContent, string(cacheContent))
+}


### PR DESCRIPTION
I add a class `NewCachedMatcher` which cache result of matcher and reuse it in case of failure etc.