### PR TITLE
Improve github matcher error handling

### DIFF
--- a/external/github_test.go
+++ b/external/github_test.go
@@ -17,7 +17,6 @@ func init() {
 }
 
 func TestGitHubMatcherValidEmail(t *testing.T) {
-	t.Skip()
 	matcher, _ := NewGitHubMatcher("", githubTestToken)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
 - try 3 times if you do not get 200 code.
 - Do not fail all processing if the external match fails for one user. 