### PR TITLE
Revert "Add postgres output format"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
 install:
   - make dependencies
 
-before_script:
-  - docker-compose up -d postgres
-  - sleep 5
-
 script:
   - make test-coverage
   # make codecov
@@ -42,7 +38,6 @@ matrix:
             - python3-pip
       install:
         - make install-dev-deps
-      before_script: skip
       script:
         - make check-style check-generate
     - stage: test
@@ -54,12 +49,14 @@ matrix:
             - libsnappy-dev
       install:
         - pip3 install -r ./parquet2sql/requirements.txt
+      before_script:
+        - docker-compose up -d postgres
+        - sleep 5
       script:
         - python3 -m unittest discover ./parquet2sql
     - stage: deploy
       go: 1.12.x
       install: skip
-      before_script: skip
       script:
         - make packages
       deploy:

--- a/cmd/match-identities/main.go
+++ b/cmd/match-identities/main.go
@@ -29,13 +29,6 @@ type cliArgs struct {
 	Cache         string
 	ExternalCache string
 	MaxIdentities int
-	OutputFormat  string
-	PgHost        string
-	PgPort        string
-	PgUser        string
-	PgPassword    string
-	PgDb          string
-	PgTable       string
 }
 
 func main() {
@@ -94,28 +87,13 @@ func main() {
 
 	logrus.Info("storing people")
 	start = time.Now()
-	if args.OutputFormat == "parquet" {
-		if err := people.WriteToParquet(args.Output, args.External); err != nil {
-			logrus.Fatalf("unable to store matches: %s", err)
-		}
-		logrus.WithFields(logrus.Fields{
-			"elapsed": time.Since(start),
-			"path":    args.Output,
-		}).Info("stored people")
-	} else {
-		if err := people.WriteToPostgres(args.PgHost, args.PgPort, args.PgUser, args.PgPassword, args.PgDb,
-			args.PgTable, args.External); err != nil {
-			logrus.Fatalf("unable to write to postgres: %s", err)
-		}
-		logrus.WithFields(logrus.Fields{
-			"elapsed":       time.Since(start),
-			"posgressHost":  args.PgHost,
-			"posgressPost":  args.PgPort,
-			"posgressUser":  args.PgUser,
-			"posgressDB":    args.PgDb,
-			"posgressTable": args.PgTable,
-		}).Info("stored people")
+	if err := people.WriteToParquet(args.Output, args.External); err != nil {
+		logrus.Fatalf("unable to store matches: %s", err)
 	}
+	logrus.WithFields(logrus.Fields{
+		"elapsed": time.Since(start),
+		"path":    args.Output,
+	}).Info("stored people")
 
 	reporter.Write()
 }
@@ -145,14 +123,6 @@ func parseArgs() cliArgs {
 		"If a person has more than this number of unique names and unique emails summed, "+
 			"no more identities will be merged. If the identities are matched by an external API "+
 			"or by email this limitation can be violated.")
-	flag.StringVar(&args.OutputFormat, "output-format", "parquet",
-		"Output format options are postgres or parquet.")
-	flag.StringVar(&args.PgHost, "pg-host", "0.0.0.0", "Postgres database host address.")
-	flag.StringVar(&args.PgPort, "pg-port", "5432", "Postgres database port.")
-	flag.StringVar(&args.PgUser, "pg-user", "superset", "Postgres database username.")
-	flag.StringVar(&args.PgPassword, "pg-pass", "superset", "Postgres database password.")
-	flag.StringVar(&args.PgDb, "pg-db", "superset", "Postgres database name.")
-	flag.StringVar(&args.PgTable, "pg-table", "identities", "Postgres table name.")
 	flag.CommandLine.SortFlags = false
 	flag.Parse()
 
@@ -160,13 +130,6 @@ func parseArgs() cliArgs {
 		if _, exists := external.Matchers[args.External]; !exists {
 			logrus.Fatalf("unsupported external matching service: %s", args.External)
 		}
-	}
-	if args.OutputFormat != "postgres" && args.OutputFormat != "parquet" {
-		logrus.Fatalf("--output-format must be either `postgres` or `parquet`, got %s",
-			args.OutputFormat)
-	}
-	if args.OutputFormat == "postgres" && args.Output != "" {
-		logrus.Fatalf("--output must not be set if --output-format is postgres")
 	}
 	return args
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
-	github.com/lib/pq v1.2.0
 	github.com/mjibson/esc v0.2.0
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
-github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=


### PR DESCRIPTION
This reverts commit 1993efb239363638eeefa8f6604e10ceb004dc28.
Since we have python utility (https://github.com/src-d/identity-matching/pull/46) for that we do not need Postgres output format 
Signed-off-by: Konstantin Slavnov <konstantin@sourced.tech>