### PR TITLE
[WIP] fast GitHub match with GetCommit API

### DIFF
--- a/cmd/match-identities/main.go
+++ b/cmd/match-identities/main.go
@@ -66,7 +66,7 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("unable to load the blacklist: %v", err)
 	}
-	people, nameFreqs, err := idmatch.FindPeople(ctx, connStr, args.Cache, blacklist)
+	people, nameFreqs, err := idmatch.FindPeople(ctx, connStr, args.Cache, blacklist, extmatcher)
 	if err != nil {
 		logrus.Fatalf("unable to find people: %v", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   gitbase:
-    image: srcd/gitbase:v0.23.1
+    image: srcd/gitbase:v0.24.0-beta3
     restart: unless-stopped
     ports:
       - 3306:3306

--- a/external/cached_matcher.go
+++ b/external/cached_matcher.go
@@ -77,6 +77,12 @@ func (m CachedMatcher) DumpCache() error {
 	return m.cache.DumpCache()
 }
 
+//FIXME
+func (m CachedMatcher) ScanCommit(ctx context.Context, repo, email, commit string) error {
+	cs := m.matcher.(CommitScanner)
+	return cs.ScanCommit(ctx, repo, email, commit)
+}
+
 // MatchByEmail returns the latest GitHub user with the given email.
 // If email was fetched already it uses cached value.
 // MatchByEmail runs `matcher.MatchByEmail` if not.

--- a/external/matcher.go
+++ b/external/matcher.go
@@ -10,6 +10,12 @@ type Matcher interface {
 	MatchByEmail(ctx context.Context, email string) (user, name string, err error)
 }
 
+// CommitScanner defines an external matching service that can scan commit
+// hashes before matching emails.
+type CommitScanner interface {
+	ScanCommit(ctx context.Context, repo, email, commit string) error
+}
+
 // MatcherConstructor is the Matcher constructor function type.
 type MatcherConstructor func(apiURL, token string) (Matcher, error)
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/src-d/eee-identity-matching
 require (
 	github.com/apache/thrift v0.12.0 // indirect
 	github.com/briandowns/spinner v1.6.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/snappy v0.0.1 // indirect
-	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-github/v28 v28.1.1
 	github.com/mjibson/esc v0.2.0
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.3.0
@@ -20,5 +21,4 @@ require (
 	golang.org/x/text v0.3.0
 	golang.org/x/tools v0.0.0-20190709211700-7b25e351ac0e
 	gonum.org/v1/gonum v0.0.0-20190624220246-e34e6b933b2b
-	gopkg.in/google/go-github.v15 v15.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
+github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -32,6 +32,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/smola/go-github/v28 v28.9.0 h1:WFZAtB7cFI/R2fk/ZqT6bwHEDXXYstHoHF/u6/HB5sQ=
+github.com/smola/go-github/v28 v28.9.0/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -62,12 +64,14 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190219183015-4b83411ed2b3 h1:OFrJ/rEn4wUq1PbIHcIdfOGIy3uCTe5XOealV2ngn/w=
 golang.org/x/oauth2 v0.0.0-20190219183015-4b83411ed2b3/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -85,8 +89,7 @@ gonum.org/v1/gonum v0.0.0-20190624220246-e34e6b933b2b h1:B1drcdqog/XZuRy27GcSpP9
 gonum.org/v1/gonum v0.0.0-20190624220246-e34e6b933b2b/go.mod h1:03dgh78c4UvU1WksguQ/lvJQXbezKQGJSrwwRq5MraQ=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-gopkg.in/google/go-github.v15 v15.0.0 h1:cT2oL8cepTN0y1qjicixn/r4ZRwn6/pkkO1JNoMls2g=
-gopkg.in/google/go-github.v15 v15.0.0/go.mod h1:l5hcbHSKRLPHjIKB0rFqYBNFUOFpa6iG6+JdaxRuqMo=

--- a/matching.go
+++ b/matching.go
@@ -3,6 +3,7 @@ package idmatch
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -206,6 +207,10 @@ func ReducePeople(people People, matcher external.Matcher, blacklist Blacklist,
 		}
 	}
 	mean, std := stat.MeanStdDev(componentsSize, nil)
+	// If std is NaN, serialization to JSON will fail
+	if math.IsNaN(std) {
+		std = 0
+	}
 	reporter.Commit("connected component size mean", mean)
 	reporter.Commit("connected component size std", std)
 	reporter.Commit("connected component size max", floats.Max(componentsSize))

--- a/people.go
+++ b/people.go
@@ -359,7 +359,7 @@ func getNamesFreqs(persons []rawPerson) (map[string]int, error) {
 	return freqs, nil
 }
 
-const findPeopleSQL = `SELECT c.repository_id, c.commit_author_name, c.commit_author_email, FIRST(c.commit_hash) AS commit_hash
+const findPeopleSQL = `SELECT c.repository_id, c.commit_author_name, c.commit_author_email, MAX(c.commit_hash) AS commit_hash
 FROM commits c
 GROUP BY 1, 2, 3;`
 

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -3,6 +3,8 @@ package reporter
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 var report = map[string]interface{}{}
@@ -32,6 +34,7 @@ func Increment(key string) int {
 
 // Write function prints report to stdout and clear all values
 func Write() {
+	spew.Dump(report) //XXX: debug
 	if jsonString, err := json.Marshal(report); err == nil {
 		fmt.Println(string(jsonString))
 	} else {


### PR DESCRIPTION
## What?

- Adds faster GitHub matching based on repositories API instead of search.
- The current approach works like this:
  - On FindPeople (when retrieving from DB, not when using raw cache), it gets an arbitrary commit hash for each (repo, author_name, author_email).
  - The repo and commit hash are used to call the GitHub API and retrieve the GitHub username, which is then cached.
  - On ReducePeople, the previous cache is used to get the GitHub email to username mapping, and a subsequent API call is still done to retrieve the name.

## Why?
This removes the need for the search API, which has much lower API quota limits. For an organization like pytorch, it can fit the process within 1 hour limit, as opposed to a few hours.

## How to improve?
This pull request is a completely dirty approach that does not work properly with the in-disk caches (they should be removed before running) and doesn't respect the separation of responsibilities of each step. However, it can be improve to better fit the process as follows:

- During FindPeople step, save the arbitrary commit along (repo, author_name, author_email).
- During ReducePeople, pass repo and commit to MatchByEmail, so it can do the GetCommit call as needed.

Note that this requires that `repository_id` from gitbase is a proper GitHub URL and not an arbitrary path. This is the case for source{d} CE imported repo, for example, but may not be the case in other scenarios. So probably `MatchByEmail` should fallback to the Search API when the given repo does not match the GitHub pattern.